### PR TITLE
[L1-114] Update component short description

### DIFF
--- a/component_config/component_short_description.md
+++ b/component_config/component_short_description.md
@@ -1,1 +1,1 @@
-Apache Parquet is a free and open-source column-oriented data storage format of the Apache Hadoop ecosystem.
+Converts Parquet files to a single CSV.


### PR DESCRIPTION
Batch cleanup of component short descriptions (the one-liner in the platform component list) - they described the vendor product instead of what the component does.

Tracked in https://linear.app/keboola/issue/L1-114/make-component-short-descriptions-consistent-support-13792 (SUPPORT-13792). Reviewed and approved by Component Factory.

Changes in this repo:
- `kds-team.processor-parquet2csv` -> Converts Parquet files to a single CSV.

One-line content change to `component_config/component_short_description.md`. Please review wording and merge.